### PR TITLE
Updates spring-cloud dependencies to Dalston version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>Dalston.M1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-etcd-dependencies</artifactId>
 				<version>${project.version}</version>
 				<type>pom</type>
@@ -65,17 +72,25 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
+					<id>spring-snapshots-local</id>
+					<name>Spring Snapshots Local</name>
 					<url>http://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
 				</repository>
 				<repository>
+					<id>spring-milestones-local</id>
+					<name>Spring Milestones Local</name>
+					<url>http://repo.spring.io/libs-milestone-local</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>http://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -91,17 +106,33 @@
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
+					<id>spring-snapshots-local</id>
+					<name>Spring Snapshots Local</name>
 					<url>http://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
 				</pluginRepository>
 				<pluginRepository>
+					<id>spring-milestones-local</id>
+					<name>Spring Milestones Local</name>
+					<url>http://repo.spring.io/libs-milestone-local</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</pluginRepository>
+				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>http://repo.spring.io/milestone</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</pluginRepository>
+				<pluginRepository>
+					<id>spring-releases</id>
+					<name>Spring Releases</name>
+					<url>http://repo.spring.io/release</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Dalston.M1</version>
+				<version>Dalston.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-etcd-dependencies/pom.xml
+++ b/spring-cloud-etcd-dependencies/pom.xml
@@ -21,8 +21,6 @@
 		<spring-cloud-commons.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<archaius.version>0.7.1</archaius.version>
-		<feign.version>8.7.1</feign.version>
-		<ribbon.version>2.1.0</ribbon.version>
 		<etcd4j.version>2.7.0</etcd4j.version>
 		<netty.version>4.1.0.Beta5</netty.version>
 		<common.configuration.version>1.8</common.configuration.version>
@@ -52,6 +50,11 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-commons</artifactId>
 				<version>${spring-cloud-commons.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-netflix</artifactId>
+				<version>${spring-cloud-netflix.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -101,26 +104,6 @@
 				<groupId>commons-configuration</groupId>
 				<artifactId>commons-configuration</artifactId>
 				<version>${common.configuration.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.netflix.ribbon</groupId>
-				<artifactId>ribbon</artifactId>
-				<version>${ribbon.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.netflix.ribbon</groupId>
-				<artifactId>ribbon-core</artifactId>
-				<version>${ribbon.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.netflix.ribbon</groupId>
-				<artifactId>ribbon-httpclient</artifactId>
-				<version>${ribbon.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.netflix.ribbon</groupId>
-				<artifactId>ribbon-loadbalancer</artifactId>
-				<version>${ribbon.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mousio</groupId>


### PR DESCRIPTION
Hi,

This PR adds/updates spring-cloud-commons and spring-cloud-netflix to Dalston version. This also removes explicit ribbon and feign version configurations. Also see #34.

Please review and pull.

Thanks,
Venil